### PR TITLE
Stub in all basic API call.  More calls may be needed, but this is a good start.

### DIFF
--- a/lib/Frontier.pm
+++ b/lib/Frontier.pm
@@ -2,10 +2,29 @@ package Frontier;
 
 use strict;
 use warnings;
-use base qw(Respite::Base Frontier::API);
+use base qw(Respite::Base);
 use Cache::Memcached::Fast;
 use Time::HiRes qw(time);
 use Throw qw(throw);
+
+sub api_meta {
+    return shift->{'api_meta'} ||= { # vtable cached here
+        namespaces => {
+            ship => {
+                match => '__',
+                package => 'Frontier::API',
+            },
+            board => {
+                match => '__',
+                package => 'Frontier::Board',
+            },
+            multi => {
+                match => '__',
+                package => 'Frontier::Multi',
+            },
+        },
+    };
+}
 
 sub server_init {
     my $self = shift;
@@ -40,7 +59,7 @@ sub run_method {
         $ret->{'_cached'} = time;
         $self->memd->set($cache_key,$ret,30);
     }
-    $ret->{'_cached'} = 0;
+    $ret->{'_cached'} = 0 if $cache_key;
     $ret;
 }
 

--- a/lib/Frontier/API.pm
+++ b/lib/Frontier/API.pm
@@ -158,7 +158,7 @@ sub __navigation {
 sub __weapon_fire__meta {
     my ($self,$args) = @_;
     return {
-        desc => 'Turn ship and thrust/engine power',
+        desc => 'Activate/fire a weapon.',
         ship_status => {
             energy => 0, # TODO how much is deducted or added for a non-cached call to this method
             hull   => 0, # TODO how much is deducted or added for a non-cached call to this method

--- a/lib/Frontier/API.pm
+++ b/lib/Frontier/API.pm
@@ -3,88 +3,192 @@ package Frontier::API;
 use strict;
 use warnings;
 use Throw qw(throw);
+use Frontier::MetaCommon;
 
-sub __do_multi__meta {
-    return {
-        desc => 'Cut down on latency by batching calls, they are run in the order you send',
-        args => {
-            calls => [{method=>'see individual methods for meta details'}],
-        },
-        resp => {
-            calls => [{method=>'see individual methods for meta details'}],
-        },
-    };
-}
-sub __do_multi {
-    my ($self,$args) = @_;
-    my $ret = {};
-    foreach my $call (@{$args->{'calls'}}) {
-        my $method = [keys %$call]->[0];
-        my $args = $call->{$method};
-        $args = ref $args eq 'HASH' ? $args : {};
-        my $resp = eval{$self->run_method($method,$args)} || $@;
-        push @{$ret->{'calls'}}, {$method => $resp};
-    }
-    return $ret;
-}
+sub new { __PACKAGE__ } # For Respite::Server
 
-sub __new_board__meta {
-    my ($self,$args) = @_;
-    return {
-        desc => 'Start a new game board',
-        args => {
-            board_pass => {
-                desc => 'The new password all ships will need to connect to this board',
-                type=>'STRING',
-                required => 1,
-            },
-        },
-        resp => {
-        },
-    };
-}
-
-sub __new_board {
-    my ($self,$args) = @_;
-    {TODO=>1};
-}
-
-sub __new_ship__meta {
+sub __new__meta {
     my ($self,$args) = @_;
     return {
         desc => 'Create a new ship',
         args => {
-            ship_id => {
-                type=>'UINT',
-                required => 1,
-            },
-            ship_pass => {
-                desc => 'The password used when performing any ship action',
-                type=>'STRING',
-                required => 1,
-            },
-            board_pass => {
-                desc => 'The new password all ships will need to connect to this board',
-                type=>'STRING',
-                required => 1,
-            },
+            ship_name => $Frontier::MetaCommon::args->{'ship_name'},
+            ship_pass => $Frontier::MetaCommon::args->{'ship_pass'},
+            board_pass => $Frontier::MetaCommon::args->{'board_pass'},
+        },
+        resp => $self->__info__meta()->{'resp'},
+    };
+}
+
+sub __new {
+    my ($self,$args) = @_;
+
+    $args->{'ship_id'} = 123; # TODO make the ship
+
+    $self->run_method('ship_info',$args);
+}
+
+sub __info__meta {
+    my ($self,$args) = @_;
+    return {
+        desc => 'Information about your ship',
+        args => {
+            ship_id => $Frontier::MetaCommon::args->{'ship_id'},
+            ship_pass => $Frontier::MetaCommon::args->{'ship_pass'},
         },
         resp => {
+            ship_id => $Frontier::MetaCommon::args->{'ship_id'}->{'desc'},
+        }
+    };
+}
+
+sub __info {
+    my ($self,$args) = @_;
+    {TODO=>1};
+}
+
+sub __navigation__meta {
+    my ($self,$args) = @_;
+    return {
+        desc => 'Turn ship and thrust/engine power',
+        ship_status => {
+            energy => 0, # TODO how much is deducted or added for a non-cached call to this method
+            hull   => 0, # TODO how much is deducted or added for a non-cached call to this method
+            shield => 0, # TODO how much is deducted or added for a non-cached call to this method
+        },
+        args => {
+            ship_id => $Frontier::MetaCommon::args->{'ship_id'},
+            ship_pass => $Frontier::MetaCommon::args->{'ship_pass'},
+            ship_radians => {desc=>'TODO'},
+            ship_engine_power => {desc=>'TODO'},
+        },
+        resp => {
+            TODO => 1,
         },
     };
 }
 
-sub __new_ship {
+sub __navigation {
+    my ($self,$args) = @_;
+    {TODO=>1};
+}
+
+sub __repair_hull__meta {
+    my ($self,$args) = @_;
+    return {
+        desc => 'Activate/Deactivate hull repairs.  Automatically turns off if there is not sufficient energy.',
+        ship_status => {
+            energy_drain => 0, # TODO how much added/drained per time slice
+            hull_drain => 0, # TODO how much added/drained per time slice
+            hull_drain => 0, # TODO how much added/drained per time slice
+            energy => 0, # TODO how much is deducted or added for a non-cached call to this method
+            hull   => 0, # TODO how much is deducted or added for a non-cached call to this method
+            shield => 0, # TODO how much is deducted or added for a non-cached call to this method
+        },
+        args => {
+            ship_id => $Frontier::MetaCommon::args->{'ship_id'},
+            ship_pass => $Frontier::MetaCommon::args->{'ship_pass'},
+            
+        },
+        resp => {
+            TODO => 1,
+        },
+    };
+}
+
+sub __repair_shield {
+    my ($self,$args) = @_;
+    {TODO=>1};
+}
+
+sub __repair_shield__meta {
+    my ($self,$args) = @_;
+    return {
+        desc => 'Activate/Deactivate shield repairs.  Automatically turns off if there is not sufficient energy.',
+        ship_status => {
+            energy_drain => 0, # TODO how much added/drained per time slice
+            hull_drain => 0, # TODO how much added/drained per time slice
+            hull_drain => 0, # TODO how much added/drained per time slice
+            energy => 0, # TODO how much is deducted or added for a non-cached call to this method
+            hull   => 0, # TODO how much is deducted or added for a non-cached call to this method
+            shield => 0, # TODO how much is deducted or added for a non-cached call to this method
+        },
+        args => {
+            ship_id => $Frontier::MetaCommon::args->{'ship_id'},
+            ship_pass => $Frontier::MetaCommon::args->{'ship_pass'},
+            
+        },
+        resp => {
+            TODO => 1,
+        },
+    };
+}
+
+sub __repair_shield {
+    my ($self,$args) = @_;
+    {TODO=>1};
+}
+
+sub __navigation__meta {
+    my ($self,$args) = @_;
+    return {
+        desc => 'Turn ship and thrust/engine power',
+        ship_status => {
+            energy => 0, # TODO how much is deducted or added for a non-cached call to this method
+            hull   => 0, # TODO how much is deducted or added for a non-cached call to this method
+            shield => 0, # TODO how much is deducted or added for a non-cached call to this method
+        },
+        args => {
+            ship_id => $Frontier::MetaCommon::args->{'ship_id'},
+            ship_pass => $Frontier::MetaCommon::args->{'ship_pass'},
+            ship_radians => {desc=>'TODO'},
+            ship_engine_power => {desc=>'TODO'},
+        },
+        resp => {
+            TODO => 1,
+        },
+    };
+}
+
+sub __navigation {
+    my ($self,$args) = @_;
+    {TODO=>1};
+}
+
+sub __weapon_fire__meta {
+    my ($self,$args) = @_;
+    return {
+        desc => 'Turn ship and thrust/engine power',
+        ship_status => {
+            energy => 0, # TODO how much is deducted or added for a non-cached call to this method
+            hull   => 0, # TODO how much is deducted or added for a non-cached call to this method
+            shield => 0, # TODO how much is deducted or added for a non-cached call to this method
+        },
+        args => {
+            ship_id => $Frontier::MetaCommon::args->{'ship_id'},
+            ship_pass => $Frontier::MetaCommon::args->{'ship_pass'},
+            weapon_radians => {desc=>'TODO'},
+            weapon_id => {desc=>'TODO'},
+            weapon_power => {desc=>'TODO'},
+        },
+        resp => {
+            TODO => 1,
+        },
+    };
+}
+
+sub __weapon_fire {
     my ($self,$args) = @_;
     {TODO=>1};
 }
 
 sub __scan__meta {
+    my ($self,$args) = @_;
     return {
-        desc => 'Performs a short range scan, giving details about nearby objects in play.',
+        desc => 'Performs a scan, giving details about nearby objects.',
         cacheable => {
-            cached => 1, # TODO number of seconds to cache this result per ship
-            key => [], # args to use as a cache key
+            cached => 1, # number of seconds to cache this result per ship
+            key => ['ship_id'], # args to use as a cache key
         },
         ship_status => {
             energy => 0, # TODO how much is deducted or added for a non-cached call to this method
@@ -92,18 +196,11 @@ sub __scan__meta {
             shield => 0, # TODO how much is deducted or added for a non-cached call to this method
         },
         args => {
-            ship_id => {
-                type=>'UINT',
-                required => 1,
-            },
-            ship_pass => {
-                desc => 'The password used when performing any ship action',
-                type=>'STRING',
-                required => 1,
-            },
+            ship_id => $Frontier::MetaCommon::args->{'ship_id'},
+            ship_pass => $Frontier::MetaCommon::args->{'ship_pass'},
         },
         resp => {
-            obj => {
+            obj => [{
                 id => {
                     id => 'object id, listed again for convenience',
                     img => 'Image to display for this object',
@@ -120,7 +217,7 @@ sub __scan__meta {
                     obj_radians => 'The direction the object is facing',
                     obj_speed => 'The speed the object is moving',
                 },
-            },
+            }],
             msg => ['a list of recent messages, if any'],
         },
     };
@@ -143,19 +240,6 @@ sub __scan {
         obj => $obj_ret,
         msg => ['hello from frontier '.time()],
     }
-}
-
-sub __scan_long__meta {
-    my $self = shift;
-    my $ret = $self->__scan__meta(@_);
-    $ret->{'desc'} = 'Performs a long range scan, giving basic info for objects beyond the short range scanners range.',
-    $ret->{'ship_status'}->{'energy'} = '-1TODO'; #$self->my->scanner->energy; # TODO calculated from ship stats
-    $ret;
-}
-
-sub __scan_long {
-    my ($self,$args) = @_;
-    $self->__scan($args,1);
 }
 
 sub obj_class {

--- a/lib/Frontier/Board.pm
+++ b/lib/Frontier/Board.pm
@@ -1,0 +1,73 @@
+package Frontier::Board;
+
+use strict;
+use warnings;
+use Throw qw(throw);
+
+sub new { __PACKAGE__ } # For Respite::Server
+
+sub __new__meta {
+    my ($self,$args) = @_;
+    return {
+        desc => 'Start a new game board',
+        args => {
+            board_name => $Frontier::MetaCommon::args->{'board_name'},
+            board_pass => $Frontier::MetaCommon::args->{'board_pass'},
+        },
+        resp => {
+            board_id => $Frontier::MetaCommon::args->{'board_id'}->{'desc'},
+        },
+    };
+}
+
+sub __new {
+    my ($self,$args) = @_;
+    {TODO=>1};
+}
+
+sub __info__meta {
+    my ($self,$args) = @_;
+    return {
+        desc => 'Details about the players/ships for a board',
+        args => {
+            board_id => $Frontier::MetaCommon::args->{'board_id'},
+            board_pass => $Frontier::MetaCommon::args->{'board_pass'},
+        },
+        resp => {
+            board_id => $Frontier::MetaCommon::args->{'board_id'}->{'desc'},
+            players => [{
+                ship_id => $Frontier::MetaCommon::args->{'ship_id'}->{'desc'},
+                TODO => 'other ship data will go here eventually',
+            }],
+        },
+    };
+}
+
+sub __info {
+    my ($self,$args) = @_;
+    {TODO=>1};
+}
+
+sub __list__meta {
+    my ($self,$args) = @_;
+    return {
+        desc => 'List of active or recently active boards',
+        args => {},
+        resp => {
+            rows => [{
+                board_id => $Frontier::MetaCommon::args->{'board_id'}->{'desc'},
+                board_name => $Frontier::MetaCommon::args->{'board_name'}->{'desc'},
+                #curent_players => 'TODO',
+                #max_players => 'TODO',
+                TODO => 'other board info will go here eventually',
+            }],
+        },
+    };
+}
+
+sub __list {
+    my ($self,$args) = @_;
+    {TODO=>1};
+}
+
+1;

--- a/lib/Frontier/MetaCommon.pm
+++ b/lib/Frontier/MetaCommon.pm
@@ -1,0 +1,39 @@
+package Frontier::MetaCommon;
+use strict;
+use warnings;
+use Throw qw(throw);
+
+our $args = {
+    ship_id => {
+        desc     => 'Your ship_id (provided by ship_new)', 
+        type     => 'UINT',
+        required => 1,
+    },
+    ship_name => {
+        desc     => 'Displayed in board_info and ship_scan results',
+        type     => 'STRING',
+        required => 1,
+    },
+    ship_pass => {
+        desc     => 'Required when performing any ship action',
+        type     => 'STRING',
+        required => 1,
+    },
+    board_id => {
+        desc     => 'Your board_id (provided by board_new)',
+        type     => 'UINT',
+        required => 1,
+    },
+    board_name => {
+        desc     => 'Displayed in board_info and board_list results',
+        type     => 'STRING',
+        required => 1,
+    },
+    board_pass => {
+        desc     => 'The new password all ships will need to connect to this board',
+        type     => 'STRING',
+        required => 1,
+    },
+};
+
+1;

--- a/lib/Frontier/Multi.pm
+++ b/lib/Frontier/Multi.pm
@@ -1,0 +1,33 @@
+package Frontier::Multi;
+use strict;
+use warnings;
+use Throw qw(throw);
+
+sub new { __PACKAGE__ } # For Respite::Server
+
+sub __run_method__meta {
+    return {
+        desc => 'Cut down on latency by batching calls, they are run in the order you send',
+        args => {
+            calls => [{method=>'see individual methods for meta details'}],
+        },
+        resp => {
+            calls => [{method=>'see individual methods for meta details'}],
+        },
+    };
+}
+
+sub __run_method {
+    my ($self,$args) = @_;
+    my $ret = {};
+    foreach my $call (@{$args->{'calls'}}) {
+        my $method = [keys %$call]->[0];
+        my $args = $call->{$method};
+        $args = ref $args eq 'HASH' ? $args : {};
+        my $resp = eval{$self->run_method($method,$args)} || $@;
+        push @{$ret->{'calls'}}, {$method => $resp};
+    }
+    return $ret;
+}
+
+1;

--- a/lib/Test/Frontier/API.pm
+++ b/lib/Test/Frontier/API.pm
@@ -44,7 +44,7 @@ sub startup : Test(startup => +6) {
 
     my ($client, $server) = setup_test_server({
         service  => 'frontier_test',
-        api_meta => 'Frontier::API',
+        api_meta => 'Frontier',
         flat     => 1,
         client_utf8_encoded => 1,
         no_ssl => 1,
@@ -59,7 +59,7 @@ sub __hello : Test(1) {
     my $resp = $self->client->hello;
     cmp_deeply(
         $resp,
-        { msg => 'hello from frontier', server_time => re('^\d+$') },
+        { _cached=>0,api_brand=>'unittest',api_ip=>'127.0.0.1',server_time => re('^\d+$'), args=>{_c=>re('.')} },
         'Call api method "hello"'
     ) or diag(explain($resp));
 }

--- a/lib/Test/Frontier/API/Ship.pm
+++ b/lib/Test/Frontier/API/Ship.pm
@@ -8,7 +8,7 @@ use base 'Test::Frontier::API';
 
 sub __ship_info : Test(1) {
     my $self = shift;
-    my $resp = $self->client->ship_info;
+    my $resp = $self->client->ship_info({ship_id=>1,ship_pass=>1});
     cmp_deeply($resp, {id => 1, name => 'foo ship-name1'}, 'Call api method "ship_info"') or diag(explain($resp));
 }
 


### PR DESCRIPTION
Note: We probably want to rename lib/Frontier/API.pm to lib/Frontier/Ship.pm

I laid them out this way so they would fit nice into API calls
```
./bin/frontier_client methods

   "methods" : {
      "board_info" : "Details about the players/ships for a board",
      "board_list" : "List of active or recently active boards",
      "board_new" : "Start a new game board",
      "hello" : "Basic call to test connection",
      "methods" : "Return a list of all known Frontier methods.  Optionally return all meta information as well",
      "multi_run_method" : "Cut down on latency by batching calls, they are run in the order you send",
      "ship_info" : "Information about your ship",
      "ship_navigation" : "Turn ship and thrust/engine power",
      "ship_new" : "Create a new ship",
      "ship_repair_hull" : "Activate/Deactivate hull repairs.  Automatically turns off if there is not sufficient energy.",
      "ship_repair_shield" : "Activate/Deactivate shield repairs.  Automatically turns off if there is not sufficient energy.",
      "ship_scan" : "Performs a scan, giving details about nearby objects.",
      "ship_weapon_fire" : "Activate/fire a weapon."
   }
```